### PR TITLE
binutils: add ALTERNATIVES for strings (FS#3001)

### DIFF
--- a/package/devel/binutils/Makefile
+++ b/package/devel/binutils/Makefile
@@ -49,6 +49,7 @@ define Package/binutils
   CATEGORY:=Development
   TITLE:=binutils
   DEPENDS:=+objdump +ar
+  ALTERNATIVES:=200:/usr/bin/strings:/usr/bin/binutils-strings
 endef
 
 define Package/objdump
@@ -114,7 +115,7 @@ endef
 define Package/binutils/install
 	$(INSTALL_DIR) $(1)/usr $(1)/bin
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/ $(1)/usr/
-	mv $(1)/usr/bin/strings $(1)/bin/strings
+	mv $(1)/usr/bin/strings $(1)/usr/bin/binutils-strings
 	rm -f $(1)/usr/bin/objdump
 	rm -f $(1)/usr/bin/ar
 endef


### PR DESCRIPTION
Don't move strings anymore to /bin/strings to avoid clash with
busybox /usr/bin/strings but move it to /usr/bin/binutils-strings.
Use ALTERNATIVES support to install it as /usr/bin/strings

Signed-off-by: Hans Dedecker <dedeckeh@gmail.com>
(cherry picked from commit 5f126c541a743e2ff5d8f406128d477ab5a509b4)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
