### PR TITLE
dnsmasq: fix dnssec+ntp chicken-and-egg workaround (FS#2574)

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=dnsmasq
 PKG_UPSTREAM_VERSION:=2.80
 PKG_VERSION:=$(subst test,~~test,$(subst rc,~rc,$(PKG_UPSTREAM_VERSION)))
-PKG_RELEASE:=16
+PKG_RELEASE:=16.1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_UPSTREAM_VERSION).tar.xz
 PKG_SOURCE_URL:=http://thekelleys.org.uk/dnsmasq

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -963,10 +963,9 @@ dnsmasq_start()
 		xappend "--conf-file=$TRUSTANCHORSFILE"
 		xappend "--dnssec"
 		[ -x /etc/init.d/sysntpd ] && {
-			/etc/init.d/sysntpd enabled
-			[ "$?" -ne 0 -o "$(uci_get system.ntp.enabled)" = "1" ] && {
+			if /etc/init.d/sysntpd enabled || [ "$(uci_get system.ntp.enabled)" = "1" ] ; then
 				[ -f "$TIMEVALIDFILE" ] || xappend "--dnssec-no-timecheck"
-			}
+			fi
 		}
 		append_bool "$cfg" dnsseccheckunsigned "--dnssec-check-unsigned"
 	}


### PR DESCRIPTION
Fix the test for an enabled sysntp initscript in dnsmasq.init, and get
rid of "test -o" while at it.

Issue reproduced on openwrt-19.07 with the help of pool.ntp.br and an
RTC-less ath79 router.  dnssec-no-timecheck would be clearly missing
from /var/etc/dnsmasq.conf.* while the router was still a few days in
the past due to non-working DNSSEC + DNS-based NTP server config.

The fix was tested with the router in the "DNSSEC broken state": it
properly started dnsmasq in dnssec-no-timecheck mode, and eventually ntp
was able to resolve the server name to an IP address, and set the system
time.  DNSSEC was then enabled by SIGINT through the ntp hotplug hook,
as expected.

A missing system.ntp.enabled UCI node is required for the bug to show
up.  The reasons for why it would be missing in the first place were not
investigated.

Signed-off-by: Henrique de Moraes Holschuh <henrique@nic.br>
Signed-off-by: Hans Dedecker <dedeckeh@gmail.com> [PKG_RELEASE increase]
(cherry picked from commit 556b8581a15c855b2de0efbea6b625ab16cc9daf)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
